### PR TITLE
fix: Update research consent schema version

### DIFF
--- a/GRZ/grz-schema.json
+++ b/GRZ/grz-schema.json
@@ -223,7 +223,12 @@
                   "type":"string",
                   "description":"Schema version of de.medizininformatikinitiative.kerndatensatz.consent",
                   "enum":[
-                    "2025.0.1"
+                    "2025.0.1",
+                    "2025.0.2",
+                    "2025.0.3",
+                    "2025.0.4",
+                    "2026.0.0",
+                    "2026.0.1"
                   ]
                 },
                 "presentationDate":{

--- a/GRZ/grz-schema.json
+++ b/GRZ/grz-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema":"https://json-schema.org/draft/2020-12/schema",
-  "version":"1.3.0",
+  "version":"1.3.1",
   "title":"Metadata Submission Genomic Data Center (GRZ)",
   "description":"General metadata schema for submissions to the GRZ",
   "type":"object",


### PR DESCRIPTION
So far, the GRZ schema hardcodes version 2025.0.1 for the research consent.
Update the list of allowed schema versions to include more recent versions as well as the upcoming 2026.0.1 version.